### PR TITLE
docs: align references/defaults with runtime and document fit=pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The last path segment is treated as a transform string when it contains `=`. Tra
 | `h` | Height (px) | 1-8192 | - |
 | `q` | Quality | 1-100 | 80 |
 | `f` | Output format | `jpeg`, `png`, `webp`, `avif`, `gif`, `auto` | auto (negotiated) |
-| `fit` | Resize mode | `contain`, `cover`, `fill`, `inside`, `outside` | `contain` |
+| `fit` | Resize mode | `contain`, `cover`, `fill`, `inside`, `outside`, `pad` | `contain` |
 | `g` | Crop gravity | `center`, `north`, `south`, `east`, `west`, `ne`, `nw`, `se`, `sw`, `smart`, `attention` | `center` |
 | `sharpen` | Sharpen sigma | 0.0-10.0 | - |
 | `blur` | Gaussian blur sigma | 0.1-250.0 | - |
@@ -75,7 +75,7 @@ The last path segment is treated as a transform string when it contains `=`. Tra
 | `anim` | Animation mode | `true`, `false`, `auto`, `static`, `animate` | `auto` (`true`) |
 | `frame` | Extract single frame | 0-999 | - |
 
-See [docs/transforms.md](docs/transforms.md) for full details.
+See [docs/pages/transforms.mdx](docs/pages/transforms.mdx) for full details.
 
 ## Environment Variables
 
@@ -91,7 +91,7 @@ See [docs/transforms.md](docs/transforms.md) for full details.
 | `ZIMGX_R2_ACCESS_KEY_ID` | R2/S3 access key | - |
 | `ZIMGX_R2_SECRET_ACCESS_KEY` | R2/S3 secret key | - |
 
-See [docs/configuration.md](docs/configuration.md) for the full reference.
+See [docs/pages/configuration.mdx](docs/pages/configuration.mdx) for the full reference.
 
 ## Endpoints
 
@@ -144,7 +144,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
                                  Respond
 ```
 
-See [docs/architecture.md](docs/architecture.md) for full details.
+See [docs/pages/architecture.mdx](docs/pages/architecture.mdx) for full details.
 
 ## Performance
 
@@ -168,10 +168,10 @@ Run benchmarks locally with `zig build bench`.
 
 ## Documentation
 
-- [Configuration Reference](docs/configuration.md) &mdash; all `ZIMGX_*` environment variables
-- [Transform Parameters](docs/transforms.md) &mdash; resize, format, effects
-- [Deployment Guide](docs/deployment.md) &mdash; Docker, Compose, health checks
-- [Architecture](docs/architecture.md) &mdash; system design, module map, caching
+- [Configuration Reference](docs/pages/configuration.mdx) &mdash; all `ZIMGX_*` environment variables
+- [Transform Parameters](docs/pages/transforms.mdx) &mdash; resize, format, effects
+- [Deployment Guide](docs/pages/deployment.mdx) &mdash; Docker, Compose, health checks
+- [Architecture](docs/pages/architecture.mdx) &mdash; system design, module map, caching
 
 ## License
 

--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -176,6 +176,7 @@ Uses `vips_thumbnail_image` with fit mode mapping:
 | `fill` | `VIPS_SIZE_FORCE` — stretch to exact dimensions |
 | `inside` | `VIPS_SIZE_DOWN` — same as contain |
 | `outside` | `VIPS_SIZE_UP` — scale up to cover dimensions |
+| `pad` | Resize like `contain`, then embed into target canvas using background color |
 
 ### 5. Effects
 
@@ -214,7 +215,7 @@ Errors serialize to JSON:
 
 ## Threading model
 
-zimgx uses a bounded thread pool to handle concurrent requests. Each incoming connection is dispatched to a worker thread, bounded by a semaphore (`ZIMGX_SERVER_MAX_CONNECTIONS`, default 64).
+zimgx uses a bounded thread pool to handle concurrent requests. Each accepted connection is handled by a worker thread, with capacity controlled by `ZIMGX_SERVER_MAX_CONNECTIONS` (default `256`). When active connections reach that limit, new connections are rejected until capacity frees up.
 
 - **Thread-per-connection** — Each request runs on its own thread with stack-local buffers. No shared mutable state on the hot path.
 - **Thread-safe caches** — `MemoryCache` uses `std.Thread.RwLock`. `R2Cache` uses `std.Thread.Mutex`. Atomic operations protect server stats counters.

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -3,7 +3,7 @@
 ## Build from source
 
 ```bash
-# Requires: Zig 0.14+, libvips, glib headers
+# Requires: Zig 0.15+, libvips, glib headers
 zig build -Doptimize=ReleaseSafe
 ```
 

--- a/docs/pages/performance.mdx
+++ b/docs/pages/performance.mdx
@@ -33,9 +33,9 @@ zimgx handles concurrent requests using a thread pool. Each incoming connection 
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `ZIMGX_SERVER_MAX_CONNECTIONS` | `64` | Maximum concurrent connections (thread pool size) |
+| `ZIMGX_SERVER_MAX_CONNECTIONS` | `256` | Maximum concurrent connections (thread pool size) |
 
-The server can handle many concurrent requests without blocking. Under sustained load, connections beyond the pool size wait for a worker to become available.
+The server can handle many concurrent requests without blocking. Under sustained load, once active connections hit the configured limit, new connections are rejected until capacity frees up.
 
 ### Scaling horizontally
 
@@ -59,7 +59,7 @@ zimgx uses a two-tier cache to balance speed and persistence:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `ZIMGX_CACHE_MAX_SIZE_BYTES` | `536870912` (512 MiB) | Maximum L1 cache size |
-| `ZIMGX_CACHE_DEFAULT_TTL_SECONDS` | `86400` (24 hours) | Cache-Control max-age sent to clients |
+| `ZIMGX_CACHE_DEFAULT_TTL_SECONDS` | `3600` (1 hour) | Cache-Control max-age sent to clients |
 
 Increase `ZIMGX_CACHE_MAX_SIZE_BYTES` if your working set is large and you have memory to spare. The LRU eviction policy keeps the most recently accessed variants in memory.
 

--- a/docs/pages/transforms.mdx
+++ b/docs/pages/transforms.mdx
@@ -90,11 +90,14 @@ Controls how the image fits the target dimensions.
 | `fill` | Stretch to exactly fill the dimensions. Ignores aspect ratio. |
 | `inside` | Same as `contain`. |
 | `outside` | Scale up to cover the dimensions. Preserves aspect ratio. |
+| `pad` | Resize like `contain`, then letterbox onto the target canvas using the background color. |
 
 ```
 /photo.jpg/w=400,h=400,fit=cover
 /photo.jpg/w=400,h=300,fit=fill
 ```
+
+With `fit=pad`, set both `w` and `h` to force a fixed output canvas. The padding color comes from `bg`/`background` and defaults to white. For animated output, `fit=pad` currently behaves like `contain`.
 
 ## Gravity
 
@@ -201,7 +204,7 @@ Gamma correction.
 
 ### `bg` / `background`
 
-Hex RGB color to flatten alpha channels onto before encoding. Useful when converting transparent PNGs to JPEG.
+Hex RGB color used for `fit=pad` canvas fill and alpha flattening before encoding. Useful when converting transparent PNGs to JPEG.
 
 - **Format:** 6-character hex, no `#` prefix
 


### PR DESCRIPTION
This PR fixes docs-only correctness issues and aligns documentation with current runtime behavior.
- Updated README links to point to existing docs under `docs/pages/*.mdx`.
- Added `fit=pad` to transform docs and clarified pad behavior (canvas fill via bg, animated output behavior).
- Updated docs defaults to match code:
  - Zig requirement: 0.15+
  - ZIMGX_SERVER_MAX_CONNECTIONS: 256
  - ZIMGX_CACHE_DEFAULT_TTL_SECONDS: 3600 (1 hour)
- Replaced stale threading wording in architecture/performance docs to reflect actual connection-cap behavior.