### PR TITLE
fix: cache fallback

### DIFF
--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -111,6 +111,8 @@ zimgx uses a polymorphic `Cache` interface (vtable pattern) with multiple backen
 
 **Write path:** L1 is written synchronously (fast). L2 is written asynchronously on a background thread to keep the R2 upload off the response path.
 
+**Write fallback:** If a cache write is skipped (for example, cache disabled or variant too large for L1), the image response is still returned uncached.
+
 **Delete path:** Delete from both L1 and L2.
 
 When `ZIMGX_CACHE_ENABLED=false`, a `NoopCache` replaces all cache operations with no-ops.

--- a/docs/pages/configuration.mdx
+++ b/docs/pages/configuration.mdx
@@ -49,8 +49,8 @@ Required when `ZIMGX_ORIGIN_TYPE=r2`. All fields must be non-empty.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `ZIMGX_CACHE_ENABLED` | `bool` | `true` | Enable the in-memory L1 cache. When disabled, every request fetches from origin. |
-| `ZIMGX_CACHE_MAX_SIZE_BYTES` | `usize` | `536870912` (512 MiB) | Maximum memory for the L1 cache. Entries are evicted using LRU when exceeded. |
+| `ZIMGX_CACHE_ENABLED` | `bool` | `true` | Enable the in-memory L1 cache. When disabled, every request fetches from origin and is served uncached. |
+| `ZIMGX_CACHE_MAX_SIZE_BYTES` | `usize` | `536870912` (512 MiB) | Maximum memory for the L1 cache. Entries are evicted using LRU when exceeded; entries larger than the limit are served but not cached. |
 | `ZIMGX_CACHE_DEFAULT_TTL_SECONDS` | `u32` | `3600` | TTL for `Cache-Control: public, max-age=` headers on image responses |
 
 ## Validation

--- a/docs/pages/performance.mdx
+++ b/docs/pages/performance.mdx
@@ -52,7 +52,7 @@ zimgx uses a two-tier cache to balance speed and persistence:
 | **L1** | In-memory LRU | Fastest | Lost on restart | No |
 | **L2** | R2 / S3 | Fast | Survives restarts | Yes |
 
-**Writes are non-blocking.** When a cache miss occurs, the response is sent to the client as soon as L1 is written. The L2 write happens asynchronously in the background, keeping the R2 upload off the response path.
+**Writes are best-effort and non-blocking.** On cache misses, zimgx still returns the response even when a cache backend skips a write (for example, cache disabled or entry too large). When L2 is enabled, its write happens asynchronously in the background, keeping the R2 upload off the response path.
 
 ### Tuning the L1 cache
 


### PR DESCRIPTION
**What this fixes**

When image processing succeeds but cache storage is skipped, the server should still return the image instead of `500`.
This fixes two false-500 cases:
- cache disabled (`ZIMGX_CACHE_ENABLED=false`, NoopCache)
- oversized entries intentionally not stored by memory cache

**Changes**

- Replaced cache round-trip hard dependency with cache-or-direct fallback response path in `src/server.zig`.
- Added safe response-body ownership cleanup for uncached fallback responses.
- Added regression tests:
  - `cache disabled falls back to direct response instead of 500`
  - `oversized memory cache entry falls back to direct response`
- Updated docs to reflect best-effort cache writes and uncached fallback behavior:
  - `docs/pages/architecture.mdx`
  - `docs/pages/configuration.mdx`
  - `docs/pages/performance.mdx`