### PR TITLE
fix: guard r2 cache deinit when cache is disabled

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -474,7 +474,7 @@ pub fn run(allocator: Allocator) !void {
         break :blk nc.cache();
     };
     defer if (cfg.cache.enabled) mc.deinit();
-    defer if (use_r2) r2c.deinit();
+    defer if (use_r2 and cfg.cache.enabled) r2c.deinit();
 
     // 4. Create R2 origin fetcher (if using R2)
     if (use_r2) {


### PR DESCRIPTION
This PR fixes a runtime safety issue in the server lifecycle when `ZIMGX_ORIGIN_TYPE=r2` and `ZIMGX_CACHE_ENABLED=false`.
In that configuration, `r2c` is not initialized, but cleanup could still call `r2c.deinit()`. Since Zig treats use of `undefined` values as a bug and `defer` always runs at scope exit, this creates an invalid cleanup path.
This change makes deinitialization match initialization by guarding `r2c.deinit()` with `use_r2 and cfg.cache.enabled` in `src/server.zig`.
