### PR TITLE
fix(vips): select AV1 compression explicitly for AVIF encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+        # libheif-plugin-aomenc (the AV1 encoder AVIF output needs) is a
+        # Recommends-only dependency of libheif-dev, and GHA runners disable
+        # auto-installing recommends -- install it explicitly or AVIF-saving
+        # tests fail here while passing on any dev machine with recommends on.
+        run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-aomenc
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,14 @@ RUN cargo build --release -p imgx
 # --- Runtime stage ---
 FROM alpine
 
-RUN apk add --no-cache vips
+# vips-heif is a separate plugin package -- plain `vips` has no AVIF/HEIF
+# support, which silently breaks negotiation for any client whose Accept
+# header allows avif (avif is first in INV-7's priority order, and nearly
+# every browser either sends it explicitly or via `*/*`). libheif itself
+# loads codecs as runtime plugins too -- libheif-aom provides the actual
+# AV1 encoder AVIF output needs (vips-heif alone only gets you HEIF
+# container support with no usable encoder).
+RUN apk add --no-cache vips vips-heif libheif-aom
 
 COPY --from=build /app/target/release/imgx /usr/local/bin/imgx
 

--- a/crates/imgx-vips/src/image.rs
+++ b/crates/imgx-vips/src/image.rs
@@ -216,7 +216,14 @@ impl VipsImage {
     }
 
     /// Encode to AVIF (via the HEIF encoder). `quality` is 1-100.
+    ///
+    /// `compression` must be passed explicitly: vips_heifsave_buffer
+    /// defaults to VIPS_FOREIGN_HEIF_COMPRESSION_HEVC (x265) when it's
+    /// omitted, not AV1, silently producing HEVC-in-a-heif-container
+    /// output mislabeled as AVIF (and erroring outright on runtimes,
+    /// like Alpine's, that only ship an AV1 encoder plugin).
     pub fn save_avif(&self, quality: i32, strip: bool) -> Result<Vec<u8>, VipsError> {
+        const VIPS_FOREIGN_HEIF_COMPRESSION_AV1: i32 = 4;
         let mut buf: *mut c_void = ptr::null_mut();
         let mut len: size_t = 0;
         let rc = unsafe {
@@ -226,6 +233,8 @@ impl VipsImage {
                 &mut len,
                 c"Q".as_ptr(),
                 quality,
+                c"compression".as_ptr(),
+                VIPS_FOREIGN_HEIF_COMPRESSION_AV1,
                 c"strip".as_ptr(),
                 bool_to_int(strip),
                 ptr::null::<c_char>(),
@@ -617,6 +626,21 @@ mod tests {
         assert!(!jpeg.is_empty());
         // JPEG magic bytes
         assert_eq!(&jpeg[0..2], &[0xFF, 0xD8]);
+    }
+
+    #[test]
+    fn load_and_reencode_static_png_as_avif_round_trips() {
+        init().expect("vips init");
+        let data = fixture("test_4x4.png");
+        let img = VipsImage::from_buffer(&data).expect("load png");
+        let avif = img.save_avif(80, true).expect("encode avif");
+        assert!(!avif.is_empty());
+        // ISO BMFF ftyp box: the major brand must be "avif", confirming
+        // AV1 compression was actually selected. Omitting `compression`
+        // in the vips_heifsave_buffer call defaults to HEVC, which would
+        // instead produce a "heic"/"mif1" brand here.
+        assert_eq!(&avif[4..8], b"ftyp");
+        assert_eq!(&avif[8..12], b"avif");
     }
 
     #[test]

--- a/crates/imgx/src/server.rs
+++ b/crates/imgx/src/server.rs
@@ -339,8 +339,32 @@ async fn handle_image_request(
         }
         // Transform failed (unsupported/corrupt source, vips error, or the
         // blocking task panicked): fall back to caching/serving the raw
-        // fetched bytes rather than a 500, matching the Zig original.
-        Ok(Err(_)) | Err(_) => {
+        // fetched bytes rather than a 500, matching the Zig original. Always
+        // logged -- a silently-swallowed transform failure here previously
+        // meant every request negotiating to an unsupported format (e.g.
+        // AVIF on a runtime image missing vips-heif) served the untouched
+        // original with no visible signal anything was wrong.
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, path = %req.image_path, transform = %transform_string, "image transform failed, serving raw origin bytes");
+            let ct = tp
+                .format
+                .map(|f| f.content_type().to_string())
+                .unwrap_or_else(|| "application/octet-stream".to_string());
+            state
+                .cache
+                .put(
+                    &cache_key,
+                    CacheEntry {
+                        data: fetch_result.data.clone(),
+                        content_type: ct.clone(),
+                        created_at: now_unix(),
+                    },
+                )
+                .await;
+            build_image_response(state, fetch_result.data, ct, if_none_match)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %req.image_path, transform = %transform_string, "image transform task panicked, serving raw origin bytes");
             let ct = tp
                 .format
                 .map(|f| f.content_type().to_string())


### PR DESCRIPTION
## Summary

Found while manually verifying the new production deployment (see officialunofficial/makechain#1186): every real image transform request was silently returning the **untouched original image** instead of a resized/re-encoded one.

Root cause: `vips_heifsave_buffer` defaults to `VIPS_FOREIGN_HEIF_COMPRESSION_HEVC` when `compression` is omitted, not AV1. `save_avif()` never passed it. AVIF is first in the negotiation priority order (INV-7) and matches almost every real browser `Accept` header (explicit `image/avif` or a `*/*` wildcard), so nearly all traffic negotiated to AVIF — which then either:
- errored outright on Alpine (the runtime image only has an AV1 encoder plugin, no HEVC/x265), or
- on an environment that *does* have an HEVC encoder, would have silently produced HEVC-in-a-HEIF-container bytes mislabeled `image/avif`.

Either way, `server.rs`'s `Ok(Err(_)) | Err(_)` fallback caught the failure and served the raw origin bytes back with `Cache-Control` and a 200 — no error surfaced anywhere, because that branch never logged.

## Changes

- `imgx-vips/src/image.rs`: `save_avif()` now passes `compression = VIPS_FOREIGN_HEIF_COMPRESSION_AV1 (4)` explicitly. Added a regression test that asserts the encoded output's ISO BMFF `ftyp` major brand is `avif` (not `heic`/`mif1`) — a test that only checks "doesn't error" would not have caught this.
- `Dockerfile`: install `vips-heif` (AVIF/HEIF support is a separate Alpine plugin package, not in plain `vips`) and `libheif-aom` (libheif also loads codecs as runtime plugins — an actual AV1 encoder has to be present).
- `server.rs`: the transform-failure fallback path now logs via `tracing::warn!` with the path/transform string. This class of bug is otherwise invisible in production.

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all clean.
- Reproduced the bug and verified the fix end-to-end in a real Alpine container (matching the production Dockerfile) using `test/fixtures/bench_2000x1500.png`:
  - Before: `w=400` request → 200, `content-type: application/octet-stream`, 518993 bytes, still 2000x1500 (untouched original).
  - After: `w=400` request → 200, `content-type: image/avif`, 1735 bytes, `400x300` (confirmed via `vipsheader`), valid AVIF `ftyp` box.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Manually reproduced + verified fix in an Alpine container matching production
- [ ] Once merged, cut a release and redeploy `apps/zimgx` (officialunofficial/makechain) to the new image