### PR TITLE
ci: security scanning, MSRV enforcement, edition 2024, Docker hardening, repo hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+.github/
+target/
+docs/
+node_modules/
+.env
+.DS_Store
+*.log

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See https://docs.github.com/articles/about-codeowners for syntax.
+# Last matching pattern wins.
+
+* @christopherwxyz

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What changed and why. Link the finding/issue if this fixes one. -->
+
+## Test plan
+
+<!-- How you verified this. Prefer a checklist of concrete commands/checks over "tested manually". -->
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+      - name: Install libvips (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libvips-dev
+          version: "1.0"
+          execute_install_scripts: true
 
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
@@ -45,12 +49,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install libvips
-        # libheif-plugin-aomenc (the AV1 encoder AVIF output needs) is a
-        # Recommends-only dependency of libheif-dev, and GHA runners disable
-        # auto-installing recommends -- install it explicitly or AVIF-saving
-        # tests fail here while passing on any dev machine with recommends on.
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-aomenc
+      # libheif-plugin-aomenc (the AV1 encoder AVIF output needs) is a
+      # Recommends-only dependency of libheif-dev, and GHA runners disable
+      # auto-installing recommends -- install it explicitly or AVIF-saving
+      # tests fail here while passing on any dev machine with recommends on.
+      - name: Install libvips (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libvips-dev libheif-plugin-aomenc
+          version: "1.0"
+          execute_install_scripts: true
 
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
@@ -71,8 +79,12 @@ jobs:
           # would never catch a genuine MSRV regression on its own.
           toolchain: "1.96"
 
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+      - name: Install libvips (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libvips-dev
+          version: "1.0"
+          execute_install_scripts: true
 
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
@@ -90,8 +102,12 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-aomenc
+      - name: Install libvips (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libvips-dev libheif-plugin-aomenc
+          version: "1.0"
+          execute_install_scripts: true
 
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: mozilla-actions/sccache-action@v0.0.10
@@ -128,8 +144,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+      - name: Install libvips (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libvips-dev
+          version: "1.0"
+          execute_install_scripts: true
 
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # sccache and incremental compilation are incompatible ("incremental
+  # compilation is prohibited: Unset CARGO_INCREMENTAL to continue").
+  CARGO_INCREMENTAL: "0"
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   lint:
@@ -23,6 +28,7 @@ jobs:
       - name: Install libvips
         run: sudo apt-get update && sudo apt-get install -y libvips-dev
 
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
@@ -46,10 +52,33 @@ jobs:
         # tests fail here while passing on any dev machine with recommends on.
         run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-aomenc
 
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --workspace
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (MSRV)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          # Keep in sync with rust-version in Cargo.toml and msrv in
+          # clippy.toml. `stable` in the other jobs floats forward and
+          # would never catch a genuine MSRV regression on its own.
+          toolchain: "1.96"
+
+      - name: Install libvips
+        run: sudo apt-get update && sudo apt-get install -y libvips-dev
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check on MSRV
+        run: cargo check --workspace --all-targets
 
   coverage:
     runs-on: ubuntu-latest
@@ -65,13 +94,21 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libvips-dev libheif-plugin-aomenc
 
       - uses: taiki-e/install-action@cargo-llvm-cov
-
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
 
       # Visibility only for now, no --fail-under-* threshold -- this
       # establishes a baseline before turning it into a hard gate.
       - name: Generate coverage summary
         run: cargo llvm-cov --workspace --summary-only >> "$GITHUB_STEP_SUMMARY"
+
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
 
   build:
     needs: [lint, test]
@@ -85,6 +122,7 @@ jobs:
       - name: Install libvips
         run: sudo apt-get update && sudo apt-get install -y libvips-dev
 
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
 
       - name: Build (release)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,15 @@ jobs:
 
   deny:
     runs-on: ubuntu-latest
+    # cargo-deny-action runs cargo inside its own Docker container, which
+    # doesn't have sccache installed -- the workflow-level RUSTC_WRAPPER
+    # env leaking in here makes every rustc invocation fail immediately
+    # ("could not execute process `sccache ...`"). This job doesn't
+    # compile anything itself, so there's nothing sccache would help with
+    # anyway; just unset it.
+    env:
+      RUSTC_WRAPPER: ""
+      SCCACHE_GHA_ENABLED: ""
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,3 +40,36 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  scan:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Scans by digest (from the build job's output), not a tag -- the
+      # exact multi-arch image that was just pushed, not whatever a
+      # mutable tag happens to point at by the time this job runs.
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}@${{ needs.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to imgx
+
+## Setup
+
+Requires Rust (stable) and libvips 8.14+ (`brew install vips` on macOS, `apt-get install libvips-dev` on Debian/Ubuntu).
+
+```sh
+cargo build --workspace
+cargo test --workspace
+```
+
+See `CLAUDE.md` for the full workspace layout, code conventions, and patterns this codebase follows.
+
+## Before opening a PR
+
+```sh
+cargo fmt --all
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+All three run in CI and are required to pass.
+
+## Commit messages
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) (`feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `ci`, optionally scoped e.g. `fix(cache): ...`). `CHANGELOG.md` is generated from these via `cliff.toml`/`release-plz` — commit messages become the changelog, so make them accurate.
+
+## Tests
+
+- New behavior needs a test in the same file, `#[cfg(test)] mod tests` at the bottom (see `CLAUDE.md`'s Code Conventions).
+- If you're changing behavior that has a documented invariant in `docs/INVARIANTS.md`, update that doc alongside the code — it's the spec the test suite is checked against, not just a description.
+- Prefer a real test over a broadened `#[allow(...)]` or a skipped assertion. If a test would require infrastructure that doesn't exist yet (e.g. a new fixture format), add it rather than testing around the gap.
+
+## FFI / `unsafe` changes
+
+Any new libvips C call goes in `crates/imgx-vips`, never directly in `crates/imgx` (which is `#![forbid(unsafe_code)]`). Verify C function signatures and enum values against the actual installed libvips headers — don't guess them from memory or from another project's bindings. An omitted option isn't always a no-op: `save_avif()` once omitted the `compression` option to `vips_heifsave_buffer`, which made libvips silently default to HEVC instead of AV1 — every "AVIF" response was either failing outright or (on a runtime with an HEVC encoder) silently mislabeling HEVC-in-a-HEIF-container as `image/avif`. See `docs/INVARIANTS.md` INV-13 for the downstream cache-poisoning consequence that incident triggered.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["crates/imgx-vips", "crates/imgx"]
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
+rust-version = "1.96"
 
 [profile.release]
 lto = true
 codegen-units = 1
+strip = true
 
 # For profiling with samply (`cargo build --profile profiling -p imgx`,
 # then `samply record ./target/profiling/imgx`): same optimizations as

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # --- Build stage ---
 FROM rust:alpine AS build
 
+ARG TARGETARCH
+
 RUN apk add --no-cache vips-dev musl-dev pkgconfig cmake make g++
 
 WORKDIR /app
@@ -9,7 +11,18 @@ COPY .cargo/ .cargo/
 COPY crates/ crates/
 COPY test/ test/
 
-RUN cargo build --release -p imgx
+# Cache mounts persist independently of layer invalidation (unlike a
+# plain COPY+RUN layer, which invalidates on almost every commit since
+# crates/ changes constantly) -- id is scoped per architecture since
+# docker.yml builds amd64/arm64 concurrently and the mounts would
+# otherwise corrupt each other. The compiled binary is copied out to a
+# non-cache-mounted path before the mount unmounts: anything left inside
+# a cache mount is invisible to the later `COPY --from=build`.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETARCH} \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETARCH} \
+    --mount=type=cache,target=/app/target,id=cargo-target-${TARGETARCH} \
+    cargo build --release -p imgx && \
+    cp target/release/imgx /usr/local/bin/imgx
 
 # --- Runtime stage ---
 FROM alpine
@@ -23,7 +36,7 @@ FROM alpine
 # container support with no usable encoder).
 RUN apk add --no-cache vips vips-heif libheif-aom
 
-COPY --from=build /app/target/release/imgx /usr/local/bin/imgx
+COPY --from=build /usr/local/bin/imgx /usr/local/bin/imgx
 
 EXPOSE 8080
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Official Unofficial, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+`imgx` is deployed as a single rolling Docker image (`ghcr.io/officialunofficial/imgx`); only the latest release is supported. There is no LTS branch.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately via [GitHub Security Advisories](https://github.com/officialunofficial/imgx/security/advisories/new) rather than a public issue.
+
+Include:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce (a minimal request/config is ideal)
+- Affected version/commit
+
+We'll acknowledge reports within a few business days. `imgx` processes untrusted, remotely-fetched image data through libvips — memory-safety issues at that FFI boundary (`crates/imgx-vips`) are taken especially seriously; see `docs/INVARIANTS.md` for the documented safety invariants that boundary must uphold.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # Clippy configuration for the imgx workspace.
 # https://doc.rust-lang.org/clippy/lint_configuration.html
 
-msrv = "1.80"
+msrv = "1.96"
 
 # imgx-vips's FFI layer is inherently pointer/arg-heavy (mirroring
 # libvips' own C signatures); keep the arity threshold a little looser

--- a/crates/imgx-vips/Cargo.toml
+++ b/crates/imgx-vips/Cargo.toml
@@ -3,6 +3,7 @@ name = "imgx-vips"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 libc = "0.2"

--- a/crates/imgx-vips/src/ffi.rs
+++ b/crates/imgx-vips/src/ffi.rs
@@ -79,7 +79,7 @@ unsafe extern "C" {
     ) -> c_int;
     pub fn vips_rot(in_: *mut VipsImage, out: *mut *mut VipsImage, angle: c_int, ...) -> c_int;
     pub fn vips_flip(in_: *mut VipsImage, out: *mut *mut VipsImage, direction: c_int, ...)
-        -> c_int;
+    -> c_int;
     pub fn vips_find_trim(
         in_: *mut VipsImage,
         left: *mut c_int,

--- a/crates/imgx-vips/src/image.rs
+++ b/crates/imgx-vips/src/image.rs
@@ -1,11 +1,11 @@
-use std::ffi::{c_void, CString};
+use std::ffi::{CString, c_void};
 use std::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use libc::{c_char, size_t};
 
-use crate::error::{last_vips_error, VipsError};
+use crate::error::{VipsError, last_vips_error};
 use crate::ffi;
 
 static VIPS_INIT: Once = Once::new();
@@ -561,11 +561,7 @@ pub fn arrayjoin_vertical(images: &[VipsImage]) -> Result<VipsImage, VipsError> 
 }
 
 fn bool_to_int(v: bool) -> i32 {
-    if v {
-        1
-    } else {
-        0
-    }
+    if v { 1 } else { 0 }
 }
 
 fn op_result(

--- a/crates/imgx-vips/src/lib.rs
+++ b/crates/imgx-vips/src/lib.rs
@@ -7,15 +7,15 @@ mod ffi;
 mod image;
 
 pub use error::VipsError;
-pub use image::{arrayjoin_vertical, init, shutdown, ThumbnailOptions, VipsImage};
+pub use image::{ThumbnailOptions, VipsImage, arrayjoin_vertical, init, shutdown};
 
 /// libvips C enum constants needed to call the FFI-wrapped operations
 /// (angle, direction, size, interesting/crop mode, colorspace, extend).
 pub mod consts {
     pub use crate::ffi::{
-        VIPS_INTERPRETATION_sRGB, VIPS_ANGLE_D0, VIPS_ANGLE_D180, VIPS_ANGLE_D270, VIPS_ANGLE_D90,
-        VIPS_DIRECTION_HORIZONTAL, VIPS_DIRECTION_VERTICAL, VIPS_EXTEND_BACKGROUND,
-        VIPS_INTERESTING_ATTENTION, VIPS_INTERESTING_CENTRE, VIPS_INTERESTING_ENTROPY,
-        VIPS_INTERPRETATION_LCH, VIPS_SIZE_DOWN, VIPS_SIZE_FORCE, VIPS_SIZE_UP,
+        VIPS_ANGLE_D0, VIPS_ANGLE_D90, VIPS_ANGLE_D180, VIPS_ANGLE_D270, VIPS_DIRECTION_HORIZONTAL,
+        VIPS_DIRECTION_VERTICAL, VIPS_EXTEND_BACKGROUND, VIPS_INTERESTING_ATTENTION,
+        VIPS_INTERESTING_CENTRE, VIPS_INTERESTING_ENTROPY, VIPS_INTERPRETATION_LCH,
+        VIPS_INTERPRETATION_sRGB, VIPS_SIZE_DOWN, VIPS_SIZE_FORCE, VIPS_SIZE_UP,
     };
 }

--- a/crates/imgx/Cargo.toml
+++ b/crates/imgx/Cargo.toml
@@ -3,6 +3,7 @@ name = "imgx"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "imgx"

--- a/crates/imgx/src/cache/r2.rs
+++ b/crates/imgx/src/cache/r2.rs
@@ -164,11 +164,7 @@ fn sanitize_key(key: &str) -> Option<String> {
         out.push(ch);
         prev_slash = ch == '/';
     }
-    if out.contains("..") {
-        None
-    } else {
-        Some(out)
-    }
+    if out.contains("..") { None } else { Some(out) }
 }
 
 #[cfg(test)]

--- a/crates/imgx/src/config.rs
+++ b/crates/imgx/src/config.rs
@@ -23,13 +23,13 @@ pub enum ConfigError {
     InvalidUrl,
     #[error("invalid configuration value")]
     InvalidValue,
-    #[error("R2 origin requires endpoint, access_key_id, secret_access_key, and both bucket names to be set")]
+    #[error(
+        "R2 origin requires endpoint, access_key_id, secret_access_key, and both bucket names to be set"
+    )]
     MissingR2Config,
     #[error("server max_connections and max_request_size must not be 0")]
     InvalidServerLimit,
-    #[error(
-        "cache max_size_bytes and default_ttl_seconds must not be 0 when the cache is enabled"
-    )]
+    #[error("cache max_size_bytes and default_ttl_seconds must not be 0 when the cache is enabled")]
     InvalidCacheLimit,
     #[error("transform max_frames and max_animated_pixels must not be 0")]
     InvalidAnimationLimit,

--- a/crates/imgx/src/http/response.rs
+++ b/crates/imgx/src/http/response.rs
@@ -107,9 +107,10 @@ mod tests {
     fn generate_etag_returns_16_character_hex_string() {
         let etag = generate_etag(b"test data");
         assert_eq!(etag.len(), 16);
-        assert!(etag
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert!(
+            etag.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
     }
 
     #[test]

--- a/crates/imgx/src/main.rs
+++ b/crates/imgx/src/main.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use imgx::config::Config;
-use imgx::server::{build_router, AppState};
+use imgx::server::{AppState, build_router};
 
 // jemalloc handles the cache/pipeline's alloc-heavy, multi-threaded churn
 // (frequent same-sized image-buffer alloc/free across tokio worker

--- a/crates/imgx/src/server.rs
+++ b/crates/imgx/src/server.rs
@@ -7,16 +7,16 @@
 //! "reject new work under saturation rather than queueing it unboundedly,"
 //! not the specific mechanism.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use axum::Router;
 use axum::body::Body;
 use axum::error_handling::HandleErrorLayer;
 use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode, Uri};
+use axum::http::{HeaderMap, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
-use axum::Router;
 use tokio::sync::Semaphore;
 use tower::ServiceBuilder;
 
@@ -253,7 +253,7 @@ async fn handle_image_request(
         Err(_) => {
             return error_response(HttpError::bad_request(Some(
                 "invalid transform parameters".to_string(),
-            )))
+            )));
         }
     };
     if tp.validate().is_err() {
@@ -292,22 +292,22 @@ async fn handle_image_request(
         Err(FetchError::NotFound) => {
             return error_response(HttpError::not_found(Some(
                 "image not found at origin".to_string(),
-            )))
+            )));
         }
         Err(FetchError::Timeout) => {
             return error_response(HttpError::gateway_timeout(Some(
                 "origin server timed out".to_string(),
-            )))
+            )));
         }
         Err(FetchError::ResponseTooLarge) => {
             return error_response(HttpError::payload_too_large(Some(
                 "image exceeds size limit".to_string(),
-            )))
+            )));
         }
         Err(_) => {
             return error_response(HttpError::bad_gateway(Some(
                 "failed to fetch from origin".to_string(),
-            )))
+            )));
         }
     };
 

--- a/crates/imgx/src/transform/negotiate.rs
+++ b/crates/imgx/src/transform/negotiate.rs
@@ -87,10 +87,10 @@ pub fn negotiate_format(
     source_has_alpha: bool,
     requested_format: Option<OutputFormat>,
 ) -> OutputFormat {
-    if let Some(fmt) = requested_format {
-        if fmt != OutputFormat::Auto {
-            return fmt;
-        }
+    if let Some(fmt) = requested_format
+        && fmt != OutputFormat::Auto
+    {
+        return fmt;
     }
 
     let accept = accept_header.map(parse_accept_header).unwrap_or_default();
@@ -130,14 +130,14 @@ pub fn negotiate_animated_format(
     accept_header: Option<&str>,
     requested_format: Option<OutputFormat>,
 ) -> Option<OutputFormat> {
-    if let Some(fmt) = requested_format {
-        if fmt != OutputFormat::Auto {
-            return if fmt.supports_animation() {
-                Some(fmt)
-            } else {
-                None
-            };
-        }
+    if let Some(fmt) = requested_format
+        && fmt != OutputFormat::Auto
+    {
+        return if fmt.supports_animation() {
+            Some(fmt)
+        } else {
+            None
+        };
     }
 
     let accept = accept_header.map(parse_accept_header).unwrap_or_default();

--- a/crates/imgx/src/transform/params.rs
+++ b/crates/imgx/src/transform/params.rs
@@ -380,15 +380,15 @@ impl TransformParams {
     /// See docs/INVARIANTS.md INV-6 — this is the sole gate before values
     /// reach libvips FFI calls that do not themselves validate ranges.
     pub fn validate(&self) -> Result<(), ParseError> {
-        if let Some(w) = self.width {
-            if !(1..=8192).contains(&w) {
-                return Err(ParseError::InvalidWidth);
-            }
+        if let Some(w) = self.width
+            && !(1..=8192).contains(&w)
+        {
+            return Err(ParseError::InvalidWidth);
         }
-        if let Some(h) = self.height {
-            if !(1..=8192).contains(&h) {
-                return Err(ParseError::InvalidHeight);
-            }
+        if let Some(h) = self.height
+            && !(1..=8192).contains(&h)
+        {
+            return Err(ParseError::InvalidHeight);
         }
         if !(1..=100).contains(&self.quality) {
             return Err(ParseError::InvalidQuality);
@@ -396,45 +396,45 @@ impl TransformParams {
         if !(1.0..=5.0).contains(&self.dpr) {
             return Err(ParseError::InvalidDpr);
         }
-        if let Some(v) = self.sharpen {
-            if !(0.0..=10.0).contains(&v) {
-                return Err(ParseError::InvalidSharpen);
-            }
+        if let Some(v) = self.sharpen
+            && !(0.0..=10.0).contains(&v)
+        {
+            return Err(ParseError::InvalidSharpen);
         }
-        if let Some(v) = self.blur {
-            if !(0.1..=250.0).contains(&v) {
-                return Err(ParseError::InvalidBlur);
-            }
+        if let Some(v) = self.blur
+            && !(0.1..=250.0).contains(&v)
+        {
+            return Err(ParseError::InvalidBlur);
         }
-        if let Some(v) = self.brightness {
-            if !(0.0..=2.0).contains(&v) {
-                return Err(ParseError::InvalidBrightness);
-            }
+        if let Some(v) = self.brightness
+            && !(0.0..=2.0).contains(&v)
+        {
+            return Err(ParseError::InvalidBrightness);
         }
-        if let Some(v) = self.contrast {
-            if !(0.0..=2.0).contains(&v) {
-                return Err(ParseError::InvalidContrast);
-            }
+        if let Some(v) = self.contrast
+            && !(0.0..=2.0).contains(&v)
+        {
+            return Err(ParseError::InvalidContrast);
         }
-        if let Some(v) = self.saturation {
-            if !(0.0..=2.0).contains(&v) {
-                return Err(ParseError::InvalidSaturation);
-            }
+        if let Some(v) = self.saturation
+            && !(0.0..=2.0).contains(&v)
+        {
+            return Err(ParseError::InvalidSaturation);
         }
-        if let Some(v) = self.gamma {
-            if !(0.1..=10.0).contains(&v) {
-                return Err(ParseError::InvalidGamma);
-            }
+        if let Some(v) = self.gamma
+            && !(0.1..=10.0).contains(&v)
+        {
+            return Err(ParseError::InvalidGamma);
         }
-        if let Some(v) = self.trim {
-            if !(1.0..=100.0).contains(&v) {
-                return Err(ParseError::InvalidTrim);
-            }
+        if let Some(v) = self.trim
+            && !(1.0..=100.0).contains(&v)
+        {
+            return Err(ParseError::InvalidTrim);
         }
-        if let Some(f) = self.frame {
-            if f > 999 {
-                return Err(ParseError::InvalidFrame);
-            }
+        if let Some(f) = self.frame
+            && f > 999
+        {
+            return Err(ParseError::InvalidFrame);
         }
         Ok(())
     }
@@ -764,12 +764,14 @@ mod tests {
 
     #[test]
     fn sharpen_bounds_validation() {
-        assert!(TransformParams {
-            sharpen: Some(5.0),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                sharpen: Some(5.0),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 sharpen: Some(11.0),
@@ -790,12 +792,14 @@ mod tests {
 
     #[test]
     fn blur_bounds_validation() {
-        assert!(TransformParams {
-            blur: Some(1.0),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                blur: Some(1.0),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 blur: Some(300.0),
@@ -816,12 +820,14 @@ mod tests {
 
     #[test]
     fn dpr_bounds_validation() {
-        assert!(TransformParams {
-            dpr: 2.5,
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                dpr: 2.5,
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 dpr: 0.5,
@@ -881,18 +887,22 @@ mod tests {
 
     #[test]
     fn width_boundary_values() {
-        assert!(TransformParams {
-            width: Some(1),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
-        assert!(TransformParams {
-            width: Some(8192),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                width: Some(1),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            TransformParams {
+                width: Some(8192),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 width: Some(8193),
@@ -979,12 +989,14 @@ mod tests {
 
     #[test]
     fn brightness_bounds_validation() {
-        assert!(TransformParams {
-            brightness: Some(1.0),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                brightness: Some(1.0),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 brightness: Some(2.1),
@@ -997,12 +1009,14 @@ mod tests {
 
     #[test]
     fn contrast_bounds_validation() {
-        assert!(TransformParams {
-            contrast: Some(0.0),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                contrast: Some(0.0),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 contrast: Some(2.1),
@@ -1015,12 +1029,14 @@ mod tests {
 
     #[test]
     fn saturation_bounds_validation() {
-        assert!(TransformParams {
-            saturation: Some(1.5),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                saturation: Some(1.5),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 saturation: Some(2.1),
@@ -1033,12 +1049,14 @@ mod tests {
 
     #[test]
     fn gamma_bounds_validation() {
-        assert!(TransformParams {
-            gamma: Some(2.2),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                gamma: Some(2.2),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 gamma: Some(0.05),
@@ -1101,12 +1119,14 @@ mod tests {
 
     #[test]
     fn trim_bounds_validation() {
-        assert!(TransformParams {
-            trim: Some(50.0),
-            ..Default::default()
-        }
-        .validate()
-        .is_ok());
+        assert!(
+            TransformParams {
+                trim: Some(50.0),
+                ..Default::default()
+            }
+            .validate()
+            .is_ok()
+        );
         assert_eq!(
             TransformParams {
                 trim: Some(0.5),

--- a/crates/imgx/src/transform/pipeline.rs
+++ b/crates/imgx/src/transform/pipeline.rs
@@ -6,7 +6,7 @@
 
 use thiserror::Error;
 
-use imgx_vips::{consts, ThumbnailOptions, VipsError, VipsImage};
+use imgx_vips::{ThumbnailOptions, VipsError, VipsImage, consts};
 
 use super::negotiate;
 use super::params::{
@@ -158,12 +158,12 @@ pub fn transform(
     }
 
     // -- TRIM -- (skipped for animated output: operates on the whole stack)
-    if let Some(threshold) = tp.trim {
-        if !animated_output {
-            let (left, top, width, height) = current.find_trim(threshold as f64)?;
-            if width > 0 && height > 0 {
-                current = current.crop(left, top, width, height)?;
-            }
+    if let Some(threshold) = tp.trim
+        && !animated_output
+    {
+        let (left, top, width, height) = current.find_trim(threshold as f64)?;
+        if width > 0 && height > 0 {
+            current = current.crop(left, top, width, height)?;
         }
     }
 
@@ -459,7 +459,7 @@ fn encode_gif(image: &VipsImage) -> Result<Vec<u8>, VipsError> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::params::{parse, AnimMode};
+    use super::super::params::{AnimMode, parse};
     use super::*;
     use std::fs;
     use std::path::Path;

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# cargo-deny configuration: advisories/licenses/bans/sources.
+# https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# Deny by default (a RUSTSEC advisory with no entry here fails CI).
+ignore = []
+
+[licenses]
+# Every permissive license actually present in the dependency tree
+# (checked via `cargo deny list` against the real Cargo.lock). A license
+# expression like "MIT OR Apache-2.0 OR LGPL-2.1-or-later" (r-efi, only
+# relevant on non-Linux/macOS targets we don't build for) is satisfied by
+# any ONE listed license, so LGPL itself is deliberately not allow-listed.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "ISC",
+  "Unicode-3.0",
+  "Zlib",
+  "CC0-1.0",
+  "MIT-0",
+  "Unlicense",
+  "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Duplicate versions of the same crate are common and mostly harmless in
+# a dependency tree this size (transitive deps pinning different minor
+# versions) -- warn, don't fail CI over it.
+multiple-versions = "warn"
+# "deny" would also flag imgx's own path dependency on imgx-vips (no
+# version constraint, as normal for workspace-internal path deps) --
+# this check is meant for unpinned `foo = "*"` registry dependencies.
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Phase 3 of the CI/TDD-driven design pass (Phase 1: #9, Phase 2: #10). An audit found no cargo-deny, no Dependabot config, no LICENSE despite `Cargo.toml` declaring MIT, no CODEOWNERS/SECURITY.md/CONTRIBUTING.md/PR template, a declared-but-unenforced MSRV, no `.dockerignore`, no image vulnerability scanning, an unstripped release binary, and a Dockerfile that recompiles the full dependency tree on almost every commit.

**Stacked on #10** (not yet merged).

## Changes

- **Edition 2024 / MSRV 1.96**: verified `rust:alpine` currently ships 1.97.0. Added a dedicated `msrv` CI job pinned to 1.96 (the `stable` jobs float forward and wouldn't catch a real regression). Fixed ~13 `collapsible_if` clippy lints edition 2024's let-chains newly enable — all mechanical (`cargo clippy --fix`), verified against the full test suite (includes INV-6's boundary-validation tests).
- **`deny.toml`** + `cargo-deny-action`: license allow-list built from the actual dependency tree (via `cargo deny list`, not guessed), advisories/sources/bans all passing.
- **`.github/dependabot.yml`**: cargo/docker/github-actions, weekly.
- **Dockerfile**: BuildKit cache mounts for cargo registry/git/target. Verified locally: 95s cold build → 38s after a one-line source change. `[profile.release]` now strips symbols (verified: 5.2MB binary, `docker run` + `/health` still works; the separate `profiling` profile is unaffected).
- **`docker.yml`**: new `scan` job runs Trivy against the exact pushed digest (not a mutable tag), uploads SARIF to the Security tab.
- **`LICENSE`** (MIT, matching `Cargo.toml`), `SECURITY.md`, `.github/CODEOWNERS`, `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`.

## Test plan
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (348 tests) all clean
- [x] `cargo deny check` clean (advisories/bans/licenses/sources)
- [x] Verified Docker build + cache-mount speedup + `docker run` + `curl /health` end-to-end locally
- [x] Verified every new GitHub Action reference (`docker/login-action@v4`, `aquasecurity/trivy-action@v0.36.0`, `github/codeql-action/upload-sarif@v4`, `EmbarkStudios/cargo-deny-action@v2`, `taiki-e/install-action@cargo-llvm-cov`, `mozilla-actions/sccache-action@v0.0.10`) against the real repo/tags via `gh api`, not guessed