### PR TITLE
feat: replace custom-JSON /metrics with real Prometheus exposition format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -237,6 +237,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -348,6 +363,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
 ]
 
 [[package]]
@@ -472,6 +498,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +527,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -493,8 +546,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -515,6 +568,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -774,6 +842,8 @@ dependencies = [
  "imgx-vips",
  "jiff",
  "lru",
+ "metrics",
+ "metrics-exporter-prometheus",
  "parking_lot",
  "reqwest",
  "rusty-s3",
@@ -806,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -963,6 +1033,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,12 +1071,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1003,6 +1097,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1025,6 +1128,48 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
+dependencies = [
+ "base64",
+ "evmap",
+ "indexmap",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1140,12 +1285,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1178,7 +1347,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1216,9 +1385,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1228,7 +1413,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1243,7 +1447,34 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1473,6 +1704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1861,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -1928,10 +2171,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2008,6 +2255,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2094,6 +2350,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,10 +2375,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2214,6 +2501,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2545,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The legacy `ZIMGX_` prefix is still read as a fallback for one release during th
 |------|-------------|
 | `GET /health` | Health check &mdash; `{"status":"ok"}` |
 | `GET /ready` | Readiness probe &mdash; `{"ready":true}` |
-| `GET /metrics` | Server stats (requests, cache hits/misses, uptime) |
+| `GET /metrics` | Prometheus exposition format (requests, cache hits/misses, uptime) |
 | `GET /<path>` | Image request (with optional transforms) |
 
 ## Architecture

--- a/crates/imgx/Cargo.toml
+++ b/crates/imgx/Cargo.toml
@@ -29,6 +29,12 @@ tower-http = { version = "0.7", features = ["trace"] }
 tracing-subscriber = "0.3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 serde_json = "1"
+metrics = { version = "0.24.6", default-features = false }
+# Default features pull in an http-listener that spins up its own
+# scrape server on a second port -- unwanted, /metrics is served
+# through our existing axum router below. `default-features = false`
+# leaves just PrometheusBuilder/PrometheusHandle::render().
+metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.7"

--- a/crates/imgx/src/server.rs
+++ b/crates/imgx/src/server.rs
@@ -8,7 +8,6 @@
 //! not the specific mechanism.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use axum::Router;
@@ -17,6 +16,7 @@ use axum::error_handling::HandleErrorLayer;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusRecorder};
 use tokio::sync::Semaphore;
 use tower::ServiceBuilder;
 
@@ -95,32 +95,18 @@ impl AppOrigin {
     }
 }
 
-/// Statistics about the running server, exposed via /metrics.
-#[derive(Default)]
-pub struct ServerStats {
-    pub requests_total: AtomicU64,
-    pub cache_hits: AtomicU64,
-    pub cache_misses: AtomicU64,
-}
-
-impl ServerStats {
-    fn to_json(&self, cache_entries: usize, uptime_seconds: i64) -> String {
-        format!(
-            "{{\"requests_total\":{},\"cache_hits\":{},\"cache_misses\":{},\"cache_entries\":{},\"uptime_seconds\":{}}}",
-            self.requests_total.load(Ordering::Relaxed),
-            self.cache_hits.load(Ordering::Relaxed),
-            self.cache_misses.load(Ordering::Relaxed),
-            cache_entries,
-            uptime_seconds,
-        )
-    }
-}
-
 pub struct AppState {
     pub config: Config,
     pub cache: AppCache,
     pub origin: AppOrigin,
-    pub stats: ServerStats,
+    /// A recorder scoped to this `AppState` instance, not the process-wide
+    /// global one `metrics::set_global_recorder` would install. Each
+    /// `AppState` (and therefore each test) gets its own isolated metric
+    /// registry -- a global recorder would make counter values a shared,
+    /// racy resource across every test in the binary (they run in
+    /// parallel by default), since metric names aren't otherwise scoped
+    /// per-instance. Emit through it via `metrics::with_local_recorder`.
+    pub metrics_recorder: PrometheusRecorder,
     pub start_time: Instant,
     pub vips_semaphore: Arc<Semaphore>,
 }
@@ -174,11 +160,32 @@ impl AppState {
             .map(|n| n.get())
             .unwrap_or(4);
 
+        let metrics_recorder = PrometheusBuilder::new().build_recorder();
+        metrics::with_local_recorder(&metrics_recorder, || {
+            metrics::describe_counter!(
+                "imgx_requests_total",
+                "Total number of HTTP requests handled."
+            );
+            metrics::describe_counter!(
+                "imgx_cache_hits_total",
+                "Total number of image-transform cache hits."
+            );
+            metrics::describe_counter!(
+                "imgx_cache_misses_total",
+                "Total number of image-transform cache misses."
+            );
+            metrics::describe_gauge!(
+                "imgx_cache_entries",
+                "Current number of entries in the cache (0 for backends that don't track this)."
+            );
+            metrics::describe_gauge!("imgx_uptime_seconds", "Seconds since the server started.");
+        });
+
         Self {
             config: cfg,
             cache,
             origin,
-            stats: ServerStats::default(),
+            metrics_recorder,
             start_time: Instant::now(),
             vips_semaphore: Arc::new(Semaphore::new(permits)),
         }
@@ -218,7 +225,9 @@ async fn handle_request(
     headers: HeaderMap,
     uri: Uri,
 ) -> Response {
-    state.stats.requests_total.fetch_add(1, Ordering::Relaxed);
+    metrics::with_local_recorder(&state.metrics_recorder, || {
+        metrics::counter!("imgx_requests_total").increment(1);
+    });
 
     let if_none_match = headers
         .get(header::IF_NONE_MATCH)
@@ -230,9 +239,18 @@ async fn handle_request(
         Route::Ready => json_response(StatusCode::OK, "{\"ready\":true}"),
         Route::Metrics => {
             let cache_entries = state.cache.size().await;
-            let uptime_seconds = state.start_time.elapsed().as_secs() as i64;
-            let json = state.stats.to_json(cache_entries, uptime_seconds);
-            json_response(StatusCode::OK, &json)
+            let uptime_seconds = state.start_time.elapsed().as_secs();
+            metrics::with_local_recorder(&state.metrics_recorder, || {
+                metrics::gauge!("imgx_cache_entries").set(cache_entries as f64);
+                metrics::gauge!("imgx_uptime_seconds").set(uptime_seconds as f64);
+            });
+            let body = state.metrics_recorder.handle().render();
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+                body,
+            )
+                .into_response()
         }
         Route::NotFound => error_response(HttpError::not_found(None)),
         Route::ImageRequest(req) => {
@@ -281,10 +299,14 @@ async fn handle_image_request(
     let cache_key = cache::compute_cache_key(&req.image_path, transform_string, format_str);
 
     if let Some(entry) = state.cache.get(&cache_key).await {
-        state.stats.cache_hits.fetch_add(1, Ordering::Relaxed);
+        metrics::with_local_recorder(&state.metrics_recorder, || {
+            metrics::counter!("imgx_cache_hits_total").increment(1);
+        });
         return build_image_response(state, entry.data, entry.content_type, if_none_match);
     }
-    state.stats.cache_misses.fetch_add(1, Ordering::Relaxed);
+    metrics::with_local_recorder(&state.metrics_recorder, || {
+        metrics::counter!("imgx_cache_misses_total").increment(1);
+    });
 
     let effective_path = strip_path_prefix(&state.config.origin.path_prefix, &req.image_path);
     let fetch_result = match state.origin.fetch(effective_path).await {
@@ -504,6 +526,21 @@ mod tests {
         (status, String::from_utf8(bytes.to_vec()).unwrap())
     }
 
+    /// Reads a single metric's current value out of `state`'s own
+    /// (per-instance, not global) Prometheus recorder. Parses the
+    /// rendered exposition text rather than tracking a parallel
+    /// AtomicU64, so tests exercise the exact same code path
+    /// production scraping does. A counter that has never been
+    /// incremented isn't rendered at all (Prometheus registries only
+    /// emit touched metrics) -- treated as 0, matching counter semantics.
+    fn metric_value(state: &AppState, name: &str) -> f64 {
+        let rendered = state.metrics_recorder.handle().render();
+        rendered
+            .lines()
+            .find_map(|line| line.strip_prefix(name)?.trim().parse::<f64>().ok())
+            .unwrap_or(0.0)
+    }
+
     /// Confirms IMGX_SERVER_MAX_CONNECTIONS actually flows into the
     /// router's concurrency limiter rather than being loaded/validated
     /// and then silently ignored. max_connections=0 means the limiter
@@ -536,14 +573,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn metrics_endpoint_returns_200_with_json_stats() {
+    async fn metrics_endpoint_returns_200_with_prometheus_exposition_format() {
         let state = test_state();
         let router = build_router(Arc::clone(&state));
         let _ = get(router.clone(), "/health").await;
         let _ = get(router.clone(), "/ready").await;
         let (status, body) = get(router, "/metrics").await;
         assert_eq!(status, StatusCode::OK);
-        assert!(body.contains("\"requests_total\":3"));
+        // Every route (including /metrics itself, once it's served) counts
+        // as a request, so by the time this response body was rendered,
+        // three earlier requests (health, ready, and this one's own count
+        // at the top of handle_request) had already been recorded.
+        assert!(body.contains("# TYPE imgx_requests_total counter"));
+        assert!(body.contains("imgx_requests_total 3"));
+        assert!(body.contains("# TYPE imgx_cache_entries gauge"));
+        assert!(body.contains("# TYPE imgx_uptime_seconds gauge"));
+    }
+
+    #[tokio::test]
+    async fn metrics_content_type_is_prometheus_text_format() {
+        let router = build_router(test_state());
+        let req = axum::http::Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        let content_type = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(content_type.starts_with("text/plain"));
     }
 
     #[tokio::test]
@@ -612,8 +673,8 @@ mod tests {
         let (status, body) = get(router.clone(), "/photo.jpg/w=100").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, "not an image");
-        assert_eq!(state.stats.cache_misses.load(Ordering::Relaxed), 1);
-        assert_eq!(state.stats.cache_hits.load(Ordering::Relaxed), 0);
+        assert_eq!(metric_value(&state, "imgx_cache_misses_total"), 1.0);
+        assert_eq!(metric_value(&state, "imgx_cache_hits_total"), 0.0);
 
         // Second, identical request: if the failed transform had been
         // cached under the transform's cache key, this would be a cache
@@ -621,8 +682,8 @@ mod tests {
         let (status, body) = get(router, "/photo.jpg/w=100").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, "not an image");
-        assert_eq!(state.stats.cache_misses.load(Ordering::Relaxed), 2);
-        assert_eq!(state.stats.cache_hits.load(Ordering::Relaxed), 0);
+        assert_eq!(metric_value(&state, "imgx_cache_misses_total"), 2.0);
+        assert_eq!(metric_value(&state, "imgx_cache_hits_total"), 0.0);
     }
 
     #[tokio::test]
@@ -633,7 +694,7 @@ mod tests {
         // listening there, so this fails at fetch -- but cache_misses
         // must still have been counted before the fetch was attempted.
         let _ = get(router, "/test.jpg").await;
-        assert_eq!(state.stats.cache_misses.load(Ordering::Relaxed), 1);
+        assert_eq!(metric_value(&state, "imgx_cache_misses_total"), 1.0);
     }
 
     #[tokio::test]

--- a/docs/pages/deployment.mdx
+++ b/docs/pages/deployment.mdx
@@ -125,25 +125,37 @@ curl http://localhost:8080/ready
 
 ### `/metrics`
 
-Returns `200` with JSON statistics:
+Returns `200` with `text/plain; version=0.0.4` — standard [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/), scrapeable directly by Prometheus, Grafana Agent, the Datadog agent's OpenMetrics check, or any compatible collector:
 
-```json
-{
-  "requests_total": 1042,
-  "cache_hits": 891,
-  "cache_misses": 151,
-  "cache_entries": 148,
-  "uptime_seconds": 3600
-}
+```
+# HELP imgx_requests_total Total number of HTTP requests handled.
+# TYPE imgx_requests_total counter
+imgx_requests_total 1042
+
+# HELP imgx_cache_hits_total Total number of image-transform cache hits.
+# TYPE imgx_cache_hits_total counter
+imgx_cache_hits_total 891
+
+# HELP imgx_cache_misses_total Total number of image-transform cache misses.
+# TYPE imgx_cache_misses_total counter
+imgx_cache_misses_total 151
+
+# HELP imgx_cache_entries Current number of entries in the cache (0 for backends that don't track this).
+# TYPE imgx_cache_entries gauge
+imgx_cache_entries 148
+
+# HELP imgx_uptime_seconds Seconds since the server started.
+# TYPE imgx_uptime_seconds gauge
+imgx_uptime_seconds 3600
 ```
 
-| Field | Description |
-|-------|-------------|
-| `requests_total` | Total HTTP requests served since startup |
-| `cache_hits` | Requests served from cache |
-| `cache_misses` | Requests that required an origin fetch |
-| `cache_entries` | Current entries in the L1 memory cache |
-| `uptime_seconds` | Seconds since server startup |
+| Metric | Type | Description |
+|--------|------|-------------|
+| `imgx_requests_total` | counter | Total HTTP requests served since startup |
+| `imgx_cache_hits_total` | counter | Requests served from cache |
+| `imgx_cache_misses_total` | counter | Requests that required an origin fetch |
+| `imgx_cache_entries` | gauge | Current entries in the L1 memory cache (0 for the R2/Noop backends, which don't track this) |
+| `imgx_uptime_seconds` | gauge | Seconds since server startup |
 
 ---
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -104,7 +104,7 @@ curl http://localhost:8080/health
 curl http://localhost:8080/ready
 # {"ready":true}
 
-# Server metrics
+# Server metrics (Prometheus exposition format)
 curl http://localhost:8080/metrics
 # Request counts, cache hit/miss rates, uptime
 ```


### PR DESCRIPTION
## Summary

Phase 4 of the CI/TDD-driven design pass (Phase 1: #9, Phase 2: #10, Phase 3: #11). `/metrics` previously returned a hand-rolled JSON blob — not scrapeable by Prometheus, Grafana Agent, or any standard OpenMetrics collector without a bespoke adapter.

**Stacked on #11** (not yet merged).

## Changes

- Added `metrics` + `metrics-exporter-prometheus` (`default-features = false` — the `http-listener` feature spins up its own second scrape server, which isn't wanted; `/metrics` is served through the existing axum router).
- **Design note**: each `AppState` gets its own `PrometheusRecorder` rather than one process-wide global recorder. A global recorder would make every counter a shared, racy resource across the whole test binary (tests run in parallel, metric names aren't otherwise scoped per-instance) — per-instance recorders keep tests exactly as deterministic as the `AtomicU64` fields they replace. Emission is scoped via `metrics::with_local_recorder`.
- Same metrics as before, now real counter/gauge types with HELP text: `imgx_requests_total`, `imgx_cache_hits_total`, `imgx_cache_misses_total` (counters), `imgx_cache_entries`, `imgx_uptime_seconds` (gauges).
- Updated `docs/pages/deployment.mdx` (full field reference), `getting-started.mdx`, `README.md`.

## Test plan
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (349 tests) all clean
- [x] Verified against the real compiled binary: `curl /metrics` returns valid `text/plain; version=0.0.4`
- [x] Validated with `promtool check metrics` (`prom/prometheus` Docker image) — zero warnings after adding HELP text