### PR TITLE
chore: make RUST_LOG actually work, add optional JSON log format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ IMGX_SERVER_HOST=0.0.0.0
 IMGX_CACHE_ENABLED=true
 IMGX_CACHE_MAX_SIZE_BYTES=536870912
 
+# Logging (read directly at startup, not part of Config -- like RUST_LOG,
+# which now actually works: RUST_LOG=debug,imgx=trace)
+# IMGX_LOG_FORMAT=json   # structured JSON logs for log-shipping pipelines; default is human-readable text
+
 # Note: the legacy ZIMGX_ prefix is still read as a fallback for one
 # release during the zimgx -> imgx migration (see docs/INVARIANTS.md
 # INV-8). Prefer IMGX_ for all new configuration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,12 +2185,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/imgx/Cargo.toml
+++ b/crates/imgx/Cargo.toml
@@ -26,7 +26,7 @@ url = "2"
 axum = "0.8"
 tower = { version = "0.5", features = ["util", "limit", "load-shed"] }
 tower-http = { version = "0.7", features = ["trace"] }
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 serde_json = "1"
 metrics = { version = "0.24.6", default-features = false }

--- a/crates/imgx/src/main.rs
+++ b/crates/imgx/src/main.rs
@@ -16,7 +16,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    init_tracing();
 
     let cfg = Config::load_from_env().unwrap_or_else(|e| {
         tracing::error!(error = %e, "failed to load configuration from environment");
@@ -51,6 +51,27 @@ async fn main() {
         .expect("server error");
 
     imgx_vips::shutdown();
+}
+
+/// `tracing_subscriber::fmt::init()` (the previous setup) builds a
+/// subscriber with no `EnvFilter` layer at all -- `env-filter` isn't in
+/// tracing-subscriber's default feature set, so `RUST_LOG` silently had
+/// no effect regardless of what an operator set it to. `IMGX_LOG_FORMAT
+/// =json` switches to structured JSON output for log-shipping pipelines
+/// that parse it (e.g. Cloud Logging, Loki); anything else (including
+/// unset) keeps the human-readable default.
+fn init_tracing() {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    if std::env::var("IMGX_LOG_FORMAT").as_deref() == Ok("json") {
+        tracing_subscriber::fmt()
+            .json()
+            .with_env_filter(filter)
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    }
 }
 
 /// Wait for Ctrl+C or SIGTERM (the signal Kubernetes sends on pod

--- a/docs/pages/configuration.mdx
+++ b/docs/pages/configuration.mdx
@@ -64,6 +64,15 @@ imgx validates configuration at startup and refuses to start if:
 - `IMGX_ORIGIN_TYPE=http` and `IMGX_ORIGIN_BASE_URL` is empty
 - `IMGX_ORIGIN_TYPE=r2` and any R2 field is empty
 
+## Logging
+
+Read directly from the environment at startup (not part of `Config`, so there's no `IMGX_` prefix):
+
+| Variable | Description |
+|----------|-------------|
+| `RUST_LOG` | Standard `tracing`/`env_logger`-style filter, e.g. `RUST_LOG=debug` or `RUST_LOG=info,imgx=debug`. Defaults to `info` if unset. |
+| `IMGX_LOG_FORMAT=json` | Structured JSON log lines instead of human-readable text — useful for log-shipping pipelines (Cloud Logging, Loki, etc.) that parse structured fields. Any other value (or unset) keeps the default text format. |
+
 ## Example **.env** file
 
 ```sh


### PR DESCRIPTION
## Summary

Phase 5 of the CI/TDD-driven design pass (Phase 1: #9, Phase 2: #10, Phase 3: #11, Phase 4: #12). `tracing_subscriber::fmt::init()` builds a subscriber with no `EnvFilter` layer — `env-filter` isn't in `tracing-subscriber`'s default feature set, so `RUST_LOG` silently had no effect no matter what an operator set it to.

**Stacked on #12** (not yet merged).

## Changes

- Added `tracing-subscriber`'s `env-filter` and `json` features.
- `init_tracing()`: `EnvFilter::try_from_default_env()`, falling back to `"info"` when unset.
- `IMGX_LOG_FORMAT=json` switches to structured JSON output for log-shipping pipelines (Cloud Logging, Loki); anything else keeps the existing human-readable text format. Read directly from the environment at startup (like `RUST_LOG` itself), not part of `Config`.
- Documented both in `.env.example` and `docs/pages/configuration.mdx`.

## Test plan
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (349 tests) all clean
- [x] Verified against the real compiled binary: `RUST_LOG=error` now genuinely suppresses the startup INFO line (it did not before this change); `IMGX_LOG_FORMAT=json` produces valid structured JSON log lines