### PR TITLE
ci: fix release-plz not detecting version bumps for unpublished crates

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -78,9 +78,29 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
+      - name: Install release-plz
+        uses: taiki-e/install-action@v2
         with:
-          command: release-pr
+          tool: release-plz@0.3.159
+
+      # release-plz normally determines "next version" by diffing against
+      # the crate as published on crates.io -- but imgx/imgx-vips are
+      # publish=false deployed applications that have never been (and
+      # never will be) published there. That registry lookup always
+      # comes back "not found", and release-plz silently treats that as
+      # "nothing new to release" instead of falling back to git tags
+      # (confirmed both in production -- 6 merged fix/feat commits since
+      # v0.1.0 produced zero proposed bump -- and via a local
+      # `release-plz update` repro). Point --registry-manifest-path at a
+      # checkout of the last release tag instead, which release-plz
+      # *does* correctly diff the working tree against.
+      - name: Checkout last release tag as the comparison baseline
+        run: |
+          last_tag=$(git tag -l 'imgx-v*' | sort -V | tail -1)
+          echo "Comparing against $last_tag"
+          git worktree add /tmp/last-release "$last_tag"
+
+      - name: Run release-plz
+        run: release-plz release-pr --registry-manifest-path /tmp/last-release/Cargo.toml
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

`release-plz` determines the "next version" by diffing against the crate as published on crates.io. `imgx`/`imgx-vips` are `publish = false` deployed applications that have never been (and never will be) published there, so that lookup always returns "not found" — release-plz silently treats this as "nothing to release" instead of falling back to git tags.

**Confirmed in production**: 6 merged fix/feat/test/ci commits since the `v0.1.0` tag produced zero proposed version bump across 6 separate `release-plz-pr` runs, all logging `the repository is already up-to-date`. Reproduced locally with `release-plz update` (same result), then confirmed the fix: passing `--registry-manifest-path <checkout-of-last-release-tag>/Cargo.toml` makes it correctly diff against git and propose `0.1.0 -> 0.1.1`.

## Fix

`release-plz/action` doesn't expose that flag, so `release-plz-pr` now installs the CLI directly (pinned to `0.3.159`, the same version the action defaults to) and runs it with a worktree checkout of the latest `imgx-v*` tag as the comparison baseline.

`release-plz-release` is unaffected — `release-plz release` tags/GH-releases based on whatever Cargo.toml's version already says once `release-pr` correctly bumps it, not a live registry comparison, and it already worked correctly for the original `v0.1.0` release.

## Test plan
- [x] Reproduced the bug locally (`release-plz update` → "already up-to-date" despite 6 conventional-commit-tagged changes since the last tag)
- [x] Confirmed the fix locally (`release-plz update --registry-manifest-path <tag-checkout>/Cargo.toml` → correctly proposes `0.1.0 -> 0.1.1`)
- [ ] After merge, confirm `release-plz-pr` opens a real release PR on the next push to `main`