### PR TITLE
ci: pass --git-token explicitly to the bare release-plz CLI

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -101,6 +101,8 @@ jobs:
           git worktree add /tmp/last-release "$last_tag"
 
       - name: Run release-plz
-        run: release-plz release-pr --registry-manifest-path /tmp/last-release/Cargo.toml
+        # Unlike release-plz/action, the bare CLI doesn't read GITHUB_TOKEN
+        # automatically -- it needs --git-token explicitly.
+        run: release-plz release-pr --registry-manifest-path /tmp/last-release/Cargo.toml --git-token "$GITHUB_TOKEN"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Follow-up to #19. Unlike `release-plz/action`, the bare `release-plz` CLI doesn't read `GITHUB_TOKEN` automatically — confirmed by the immediate failure on the first run after switching `release-plz-pr` off the wrapper action: `please provide the git token with the --git-token cli argument`.

## Test plan
- [x] Verified `--git-token` is a real, accepted flag (`release-plz release-pr --help`)
- [ ] After merge, confirm `release-plz-pr` opens a real release PR on the next push to `main`