### PR TITLE
ci: fix docker.yml tag trigger/tagging for release-plz's imgx-v* tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,10 @@ name: Build and push Docker image
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+    # release-plz tags releases as `imgx-vX.Y.Z` (package-prefixed, since
+    # imgx-vips is tagged separately in the same repo) -- not the bare
+    # `vX.Y.Z` this previously matched, which never fired.
+    tags: ["imgx-v*"]
   pull_request:
     branches: [main]
 
@@ -30,8 +33,8 @@ jobs:
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=ref,event=branch
-        type=semver,pattern={{version}}
-        type=semver,pattern={{major}}.{{minor}}
+        type=match,pattern=imgx-v(.*),group=1
+        type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/imgx-v') }}
         type=sha
       cache: true
       cache-mode: max


### PR DESCRIPTION
## Summary

`docker.yml`'s tag trigger (`tags: ["v*"]`) and semver meta-tags (`type=semver,pattern={{version}}`) both assumed bare `vX.Y.Z` tags. release-plz actually tags releases as `imgx-vX.Y.Z` (package-prefixed, since `imgx-vips` is tagged separately in the same repo).

**Confirmed in production**: merging the v0.1.1 release PR (#21) created the `imgx-v0.1.1` tag correctly, but `docker.yml` never fired for it — only the main-branch push trigger ran, producing `sha-*`/`main` tags, no version tag.

## Fix
- Trigger on `imgx-v*` instead of `v*`.
- Replace the semver meta-tags rules (which need a bare `vX.Y.Z` tag to auto-parse, and also silently lose their automatic `latest` tagging when the pattern doesn't match at all) with an explicit `type=match` rule that strips the `imgx-` prefix, plus an explicit `type=raw` `latest` rule gated on the tag push itself.

## Test plan
- [x] Verified the `type=match`/`type=raw` tag-rule syntax against the real `docker/metadata-action` docs, not guessed
- [ ] Confirm on the next release that `docker.yml` fires on the `imgx-v*` tag push and produces a correctly-versioned + `latest` image tag